### PR TITLE
GitHub API Response形式を修正

### DIFF
--- a/lib/repository/github.dart
+++ b/lib/repository/github.dart
@@ -2,7 +2,7 @@ export 'github/github_client.dart';
 export 'github/github_repository.dart';
 export 'github/github_repo_repository.dart';
 
-export 'github/models/github_item.dart';
-export 'github/models/github_response.dart';
+export 'github/models/search_item.dart';
+export 'github/models/search_response.dart';
 export 'github/models/license.dart';
 export 'github/models/owner.dart';

--- a/lib/repository/github/github_repo_repository.dart
+++ b/lib/repository/github/github_repo_repository.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'github_client.dart';
 import 'github_repository.dart';
-import 'models/github_response.dart';
+import 'models/search_response.dart';
 
 /// GitHub Search API's
 class GithubRepoRepository extends GithubRepository {
@@ -16,12 +16,12 @@ class GithubRepoRepository extends GithubRepository {
   String get token => _token;
 
   @override
-  GitHubFeature get feature => GitHubFeature.repositories;
+  String get feature => 'repositories';
 
   /// Search Repositories
   ///
   /// doc: https://docs.github.com/ja/rest/search/search?apiVersion=2022-11-28#search-repositories
-  Future<GithubResponse> search(
+  Future<SearchResponse> search(
     String query, {
     Sort sort = Sort.stars,
     Order order = Order.desc,
@@ -42,11 +42,11 @@ class GithubRepoRepository extends GithubRepository {
 
     final response = await GithubClient.request(
       token: token ?? this.token,
-      url: Uri.http(GithubRepository.host, '$apiType/${feature.name}', queryParameters),
+      url: Uri.http(GithubRepository.host, '$apiType/$feature', queryParameters),
       method: HttpMethod.get,
       apiVersion: apiVersion ?? this.apiVersion,
     );
 
-    return GithubResponse.fromJson(jsonDecode(response.body), type: GitHubFeature.repositories);
+    return SearchResponse.fromJson(jsonDecode(response.body), type: SearchEntity.repositories);
   }
 }

--- a/lib/repository/github/github_repository.dart
+++ b/lib/repository/github/github_repository.dart
@@ -1,5 +1,3 @@
-import 'models/github_response.dart';
-
 abstract class GithubRepository {
   static const String host = 'api.github.com';
 
@@ -10,5 +8,5 @@ abstract class GithubRepository {
   String get apiVersion;
 
   /// GitHub API Feature Type
-  GitHubFeature get feature;
+  String get feature;
 }

--- a/lib/repository/github/models/search_item.dart
+++ b/lib/repository/github/models/search_item.dart
@@ -24,7 +24,7 @@ class RepositoryItem extends SearchItem {
     required this.size,
     required this.stargazersCount,
     required this.watchersCount,
-    required this.language,
+    this.language,
     required this.forksCount,
     required this.openIssuesCount,
     required this.defaultBranch,
@@ -49,7 +49,7 @@ class RepositoryItem extends SearchItem {
   final int size;
   final int stargazersCount;
   final int watchersCount;
-  final String language;
+  final String? language;
   final int forksCount;
   final int openIssuesCount;
   final String defaultBranch;

--- a/lib/repository/github/models/search_item.dart
+++ b/lib/repository/github/models/search_item.dart
@@ -1,11 +1,11 @@
 import 'license.dart';
 import 'owner.dart';
 
-/// Parsed as elements of the [items] property of [GitHubResponse]
-sealed class GitHubItem {}
+/// Parsed as elements of the [items] property of [SearchResponse]
+sealed class SearchItem {}
 
-/// Parsed as elements of the [items] property for the Repository's [GitHubResponse]
-class RepositoryItem extends GitHubItem {
+/// Parsed as elements of the [items] property for the Repository's [SearchResponse]
+class RepositoryItem extends SearchItem {
   RepositoryItem({
     required this.id,
     required this.nodeId,

--- a/lib/repository/github/models/search_response.dart
+++ b/lib/repository/github/models/search_response.dart
@@ -1,12 +1,12 @@
-import 'github_item.dart';
+import 'search_item.dart';
 
-enum GitHubFeature {
+enum SearchEntity {
   repositories,
 }
 
 /// GitHub API Response model
-class GithubResponse {
-  GithubResponse({
+class SearchResponse {
+  SearchResponse({
     required this.totalCount,
     required this.incompleteResults,
     required this.items,
@@ -14,18 +14,18 @@ class GithubResponse {
 
   final int totalCount;
   final bool incompleteResults;
-  final List<GitHubItem> items;
+  final List<SearchItem> items;
 
-  factory GithubResponse.fromJson(
+  factory SearchResponse.fromJson(
     Map<String, dynamic> json, {
-    required GitHubFeature type,
+    required SearchEntity type,
   }) {
-    return GithubResponse(
+    return SearchResponse(
       totalCount: json['total_count'],
       incompleteResults: json['incomplete_results'],
       items: (json['items'] as List)
           .map((item) => switch (type) {
-                GitHubFeature.repositories => RepositoryItem.fromJson(item as Map<String, dynamic>),
+                SearchEntity.repositories => RepositoryItem.fromJson(item as Map<String, dynamic>),
               })
           .toList(),
     );


### PR DESCRIPTION
`GithubResponse`として一括でパースするのではなく、Search Endpoint専用の`SearchResponse` でパースす流用に変更した。